### PR TITLE
Add python3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ sudo: false
 language: python
 python:
   - "2.7"
+  - "3.5"
+  - "3.6"
 
 install: pip install tox-travis
 script: tox

--- a/jenkins2sql/api.py
+++ b/jenkins2sql/api.py
@@ -1,4 +1,4 @@
-import ConfigParser
+import configparser
 
 from flask import Flask
 from flask import jsonify

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ subunit2sql
 requests
 flask
 pymysql
+configparser

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,9 @@ classifier =
     Programming Language :: Python
     Programming Language :: Python :: 2
     Programming Language :: Python :: 2.7
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
 
 [files]
 packages =
@@ -25,4 +28,3 @@ data_files =
 [entry_points]
 console_scripts =
     jenkins2sql = jenkins2sql.api:main
-

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,10 @@
 [tox]
-envlist = py27,pep8,pylint
+envlist = py{27,35,36},pep8,pylint
 minversion = 1.6
 skipsdist = True
 
 [testenv]
+basepython = python3
 setenv = VIRTUAL_ENV={envdir}
          PYTHONWARNINGS=default::DeprecationWarning
 passenv = TRACE_FAILONLY GENERATE_HASHES http_proxy HTTP_PROXY https_proxy HTTPS_PROXY no_proxy NO_PROXY
@@ -31,15 +32,28 @@ commands =
   coverage html -d cover
   coverage report
 
-[testenv:pep8]
+[testenv:py27]
 basepython = python2.7
+commands =
+  {[testenv]commands}
+
+[testenv:py35]
+basepython = python3.5
+commands =
+  {[testenv]commands}
+
+[testenv:py36]
+basepython = python3.6
+commands =
+  {[testenv]commands}
+
+[testenv:pep8]
 deps =
   {[testenv]deps}
 commands =
   flake8
 
 [testenv:pylint]
-basepython = python2.7
 deps =
   {[testenv]deps}
   pylint==1.8.3


### PR DESCRIPTION
This patch set adds python 3.5 and 3.6 support to the repository, as py27 is
scheduled to be EOL in 2020. This also updates Travis to perform CI
operations on py35 and py36.

Signed-off-by: Tin Lam <tin@irrational.io>